### PR TITLE
Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ This repository contains a Slim Framework OAuth middleware.
 
 Enables you to authenticate using various OAuth providers.
 
-## Install
+The middleware allows registration with various oauth services and uses a user service to store the user details.
+After registration/authentication it responds with a Authorization header which it expects to be returned as is to authorise further requests.
+It's up to the supplied user service how this is accomplished.
+
+## Installation
 
 Via Composer
 
 ``` bash
-$ composer require gabriel403/slim-oauth
+$ composer require slimphp-api/slim-oauth
 ```
 
 Requires Slim 3.0.0 or newer.
@@ -19,29 +23,84 @@ Requires Slim 3.0.0 or newer.
 ```php
 <?php
 use Slim\App;
-use Slim\OAuth\OAuthFactory;
-use Slim\OAuth\OAuthMiddleware;
+use SlimApi\OAuth\OAuthFactory;
+use SlimApi\OAuth\OAuthMiddleware;
 
-$oAuthCreds = [
+$app = new App();
+
+$container = $app->getContainer();
+
+// these should all probably be in some configuration class
+$container['oAuthCreds'] = [
     'github' => [
         'key'       => 'abc',
         'secret'    => '123',
     ]
 ];
 
-$app = new App();
+$container[SlimApi\OAuth\OAuthFactory::class]         = function($container)
+{
+    return new OAuthFactory($container->get('oAuthCreds'));
+};
 
-$app['OAuthFactory'] = new OAuthFactory($oAuthCreds);
+$container[SlimApi\OAuth\UserServiceInterface::class] = function($container)
+{
+    //user service should implement SlimApi\OAuth\UserServiceInterface
+    //user model should have a token variable to hold the random token sent to the client
+    return new Foo\Service\UserService($container->get('Foo\Model\User'));
+};
 
-$app->add(new OAuthMiddleware($app['OAuthFactory']));
+$container[SlimApi\OAuth\OAuthMiddleware::class]      = function($container)
+{
+    return new OAuthMiddleware($container->get('SlimApi\OAuth\OAuthFactory'), $container->get('SlimApi\OAuth\UserServiceInterface'));
+};
 
-$app->map(['GET'], '/auth', function ($request, $response, $args) {
-    $response->write('<a href="/auth/github">Login via GitHub</a>');
-
-    return $response;
-});
+$app->add($container->get('SlimApi\OAuth\OAuthMiddleware'));
 
 $app->run();
+```
+
+Example user service
+
+```
+<?php
+namespace Foo\Service;
+
+use SlimApi\OAuth\UserServiceInterface;
+use OAuth\Common\Service\ServiceInterface;
+
+class UserService implements UserServiceInterface {
+
+    public function __construct($userModel)
+    {
+        $this->userModel = $userModel;
+    }
+
+    public function createUser(ServiceInterface $service)
+    {
+        // request the user information from github
+        // could go further with this and check org/team membership
+        $user = json_decode($service->request('user'), true);
+
+        // create and save a new user
+        $model = new $this->userModel([
+            'oauth_token' => $service->getStorage()->retrieveAccessToken('GitHub')->getAccessToken(),
+            'token'       => 'randomstringj0' // this isn't really random, but it should be!
+        ]);
+        $model->save();
+        return $model;
+    }
+
+    public function findOrNew($authToken)
+    {
+        // retrieve the user by the authToken provided
+        // this could also be from some fast access redis db
+        $users = $this->userModel->byToken($authToken)->get();
+        $user = $users->first();
+        // or return a blank entry if it doesn't exist
+        return ($user ?: new $this->userModel);
+    }
+}
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $oAuthCreds = [
 
 $app = new App();
 
-$app['OAuthFactory'] = new OAuthFactory($oauthCreds);
+$app['OAuthFactory'] = new OAuthFactory($oAuthCreds);
 
 $app->add(new OAuthMiddleware($app['OAuthFactory']));
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ class UserService implements UserServiceInterface {
 }
 ```
 
+Once it's all configured redirecting the user to `http://domain/auth/<oauthtype>?return=<https://post.authentication/frontend>`
+where oauthtype is the service to authentication ie github and the return url parameter is where you want the user redirected to AFTER authentication.
+
 ## Credits
 
 - [Gabriel Baker](https://github.com/gabriel403)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gabriel403/slim-oauth",
+    "name": "slimphp-api/slim-oauth",
     "type": "library",
     "description": "Slim Framework CSRF protection middleware",
     "keywords": ["slim","framework","middleware","oauth"],
@@ -19,7 +19,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Slim\\OAuth\\": "src"
+            "SlimApi\\OAuth\\": "src"
         }
     }
 }

--- a/src/OAuthFactory.php
+++ b/src/OAuthFactory.php
@@ -9,7 +9,6 @@ use OAuth\ServiceFactory;
  * Factory for creating OAuth services
  */
 class OAuthFactory {
-    private $sessionName       = 'slim_oauth_middle';
     private $storageClass      = '\OAuth\Common\Storage\Session';
     private $registeredService = false;
     private $serviceFactory;
@@ -83,17 +82,5 @@ class OAuthFactory {
     public function getService()
     {
         return $this->registeredService;
-    }
-
-    /**
-     * Check if user is authenticated
-     *
-     * @return boolean              whether the user is authenticated or not
-     */
-    public function isAuthenticated()
-    {
-        $service = $this->getOrCreateByType($_SESSION['oauth_service_type']);
-
-        return $service && $this->storage->hasAccessToken($service->service());
     }
 }

--- a/src/OAuthFactory.php
+++ b/src/OAuthFactory.php
@@ -40,8 +40,6 @@ class OAuthFactory {
             return false;
         }
 
-        $_SESSION['oauth_service_type'] = $type;
-
         // Create a new instance of the URI class with the current URI, stripping the query string
         $uriFactory = new UriFactory();
         $currentUri = $uriFactory->createFromSuperGlobalArray($_SERVER);

--- a/src/OAuthFactory.php
+++ b/src/OAuthFactory.php
@@ -1,5 +1,5 @@
 <?php
-namespace Slim\OAuth;
+namespace SlimApi\OAuth;
 
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;

--- a/src/OAuthMiddleware.php
+++ b/src/OAuthMiddleware.php
@@ -91,7 +91,9 @@ class OAuthMiddleware
 
         $user     = $this->userService->findOrNew($authValue);
         $request  = $request->withAttribute('user', $user);
-        $response = $response->withHeader('Authorization', 'token '.$user->token);
+        if ($user->token) {
+            $response = $response->withHeader('Authorization', 'token '.$user->token);
+        }
 
         return $next($request, $response);
     }

--- a/src/OAuthMiddleware.php
+++ b/src/OAuthMiddleware.php
@@ -10,10 +10,9 @@ use Psr\Http\Message\ResponseInterface;
  */
 class OAuthMiddleware
 {
-    private $defaultRole  = 'guest';
-    private $returnRoute    = false;
     private $oAuthProviders = ['github'];
     private $oAuthFactory;
+    private $userService;
 
     private static $authRoute     = '/auth/(?<oAuthServiceType>\w+)';
     private static $callbackRoute = '/auth/(?<oAuthServiceType>\w+)/callback';

--- a/src/OAuthMiddleware.php
+++ b/src/OAuthMiddleware.php
@@ -1,5 +1,5 @@
 <?php
-namespace Slim\OAuth;
+namespace SlimApi\OAuth;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/UserServiceInterface.php
+++ b/src/UserServiceInterface.php
@@ -4,7 +4,6 @@ namespace SlimApi\OAuth;
 use OAuth\Common\Service\ServiceInterface;
 
 interface UserServiceInterface {
-
     /**
      * this uses the service interface, as it's down to the implementation
      * and the different service types to figure out what info to get from the api

--- a/src/UserServiceInterface.php
+++ b/src/UserServiceInterface.php
@@ -1,0 +1,75 @@
+<?php
+namespace SlimApi\OAuth;
+
+use OAuth\Common\Service\ServiceInterface;
+
+interface UserServiceInterface {
+
+    /**
+     * this uses the service interface, as it's down to the implementation
+     * and the different service types to figure out what info to get from the api
+     *
+     * e.g.with a github service, doing $service->request('user') will result in thhe following
+     * what is done with it and how it is stored is down to implementation
+     *
+     * This is also the place you should be checking if this user is actually allowed to be created,
+     * checking if the user belongs to the right org or team. Doesn't matter on an open site,
+     * but would matter for a org specific api
+     *
+     * {
+     *   "login": "octocat",
+     *   "id": 1,
+     *   "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+     *   "gravatar_id": "",
+     *   "url": "https://api.github.com/users/octocat",
+     *   "html_url": "https://github.com/octocat",
+     *   "followers_url": "https://api.github.com/users/octocat/followers",
+     *   "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+     *   "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+     *   "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+     *   "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+     *   "organizations_url": "https://api.github.com/users/octocat/orgs",
+     *   "repos_url": "https://api.github.com/users/octocat/repos",
+     *   "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+     *   "received_events_url": "https://api.github.com/users/octocat/received_events",
+     *   "type": "User",
+     *   "site_admin": false,
+     *   "name": "monalisa octocat",
+     *   "company": "GitHub",
+     *   "blog": "https://github.com/blog",
+     *   "location": "San Francisco",
+     *   "email": "octocat@github.com",
+     *   "hireable": false,
+     *   "bio": "There once was...",
+     *   "public_repos": 2,
+     *   "public_gists": 1,
+     *   "followers": 20,
+     *   "following": 0,
+     *   "created_at": "2008-01-14T04:33:35Z",
+     *   "updated_at": "2008-01-14T04:33:35Z",
+     *   "total_private_repos": 100,
+     *   "owned_private_repos": 100,
+     *   "private_gists": 81,
+     *   "disk_usage": 10000,
+     *   "collaborators": 8,
+     *   "plan": {
+     *     "name": "Medium",
+     *     "space": 400,
+     *     "private_repos": 20,
+     *     "collaborators": 0
+     *   }
+     * }
+     *
+     * @param ServiceInterface $service oauth service
+     */
+    public function createUser(ServiceInterface $service);
+
+    /**
+     * Create a user object, whether it's blank or filled,
+     * $authToken is header from Authorization so you can retrieve from db
+     * or some kind of in-memory storage redis etc
+     *
+     * @param string|false $authToken The auth token from the Authorization header
+     */
+    public function findOrNew($authToken);
+}


### PR DESCRIPTION
Removed most session stuff, as the api shouldn't use sessions.
Moved the half-assed ACL stuff out so this middleware is simply use for registration/authentication.
UserServiceInterface added so we know the passed in service is capable of Create/Retrieving users.
Switched to using headers to pass Authentication tokens back and forth between client and server.
Make scopes editable.

Updated readme to have more explanation including a sample UserService.
